### PR TITLE
Update to 1.3.3 and fix packaging issues

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = bitwig-studio-demo
 	pkgdesc = Music production system for production, remixing and performance
-	pkgver = 1.3.2
+	pkgver = 1.3.3
 	pkgrel = 1
 	url = http://www.bitwig.com
 	arch = x86_64
@@ -16,7 +16,7 @@ pkgbase = bitwig-studio-demo
 	provides = bitwig-studio
 	conflicts = bitwig-studio-demo-rc
 	options = !strip
-	source = https://downloads.bitwig.com/stable/1.3.2/bitwig-studio-1.3.2.deb
-	md5sums = 1e2785a134eb119760ba1703637283d9
+	source = https://downloads.bitwig.com/stable/1.3.3/bitwig-studio-1.3.3.deb
+	md5sums = 15b7471fcfbba6b437df8dfeb1e19ecc
 
 pkgname = bitwig-studio-demo

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = bitwig-studio-demo
 	pkgdesc = Music production system for production, remixing and performance
-	pkgver = 1.3.1
+	pkgver = 1.3.2
 	pkgrel = 1
 	url = http://www.bitwig.com
 	arch = x86_64
@@ -16,8 +16,7 @@ pkgbase = bitwig-studio-demo
 	provides = bitwig-studio
 	conflicts = bitwig-studio-demo-rc
 	options = !strip
-	source = https://downloads.bitwig.com/stable/1.3.1/bitwig-studio-1.3.1.deb
-	md5sums = 06b6a388f095529da6ceb92f6149073b
+	source = https://downloads.bitwig.com/stable/1.3.2/bitwig-studio-1.3.2.deb
+	md5sums = 1e2785a134eb119760ba1703637283d9
 
 pkgname = bitwig-studio-demo
-

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[.SRCINFO]
+indent_style = tab
+indent_size = 2

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Bitwig GmbH <support at bitwig dot com>
 
 pkgname='bitwig-studio-demo'
-pkgver='1.3.2'
+pkgver='1.3.3'
 pkgrel='1'
 pkgdesc='Music production system for production, remixing and performance'
 arch=('x86_64')
@@ -18,7 +18,7 @@ provides=('bitwig-studio')
 conflicts=('bitwig-studio-demo-rc')
 options=(!strip)
 source=("https://downloads.bitwig.com/stable/${pkgver}/bitwig-studio-${pkgver}.deb")
-md5sums=('1e2785a134eb119760ba1703637283d9')
+md5sums=('15b7471fcfbba6b437df8dfeb1e19ecc')
 
 package() {
   # Create pkgdir folders

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,24 +1,19 @@
 # Maintainer: MKzero <info at linux-web-development dot de>
 # Contributor: Bitwig GmbH <support at bitwig dot com>
-pkgname=bitwig-studio-demo
-_pkgname=bitwig-studio
-pkgver=1.3.2
-pkgrel=1
-pkgdesc="Music production system for production, remixing and performance"
-arch=( 'x86_64' )
-url="http://www.bitwig.com"
+
+pkgname='bitwig-studio-demo'
+pkgver='1.3.2'
+pkgrel='1'
+pkgdesc='Music production system for production, remixing and performance'
+arch=('x86_64')
+url='http://www.bitwig.com/'
 license=('custom')
-# This list is not anywhere near what it should be
-# and misses a lot of package names. If you find 
-# yourself in a situation where you are missing 
-# something please tell me via mail or on Github: 
+# This list is not anywhere near what it should be and misses a lot of package
+# names. If you find yourself in a situation where you are missing something,
+# please tell me via mail or Github:
 # https://github.com/mkzero/bitwig-studio-demo-aur
-depends=( 'jack' 'xdg-utils' 'zenity' 'xcb-util-wm' 'libbsd')
-optdepends=(
-             'alsa-lib'
-             'oss'
-             'libav: MP3 support'
-           )
+depends=('jack' 'xdg-utils' 'zenity' 'xcb-util-wm' 'libbsd')
+optdepends=('alsa-lib' 'oss' 'libav: MP3 support')
 provides=('bitwig-studio')
 conflicts=('bitwig-studio-demo-rc')
 options=(!strip)
@@ -26,15 +21,13 @@ source=("https://downloads.bitwig.com/stable/${pkgver}/bitwig-studio-${pkgver}.d
 md5sums=('1e2785a134eb119760ba1703637283d9')
 
 package() {
-  cd $srcdir
+  # Create pkgdir folders
+  install -d ${pkgdir}/usr/bin
+  install -d ${pkgdir}/opt/bitwig-studio
+  install -d ${pkgdir}/usr/share/{applications,icons}
+  install -d ${pkgdir}/usr/share/licenses/${pkgname}
 
-  # create pkgdir folders
-  install -d $pkgdir/usr/bin
-  install -d $pkgdir/opt/${_pkgname}
-  install -d $pkgdir/usr/share/{applications,icons}
-  install -d $pkgdir/usr/share/licenses/$pkgname
-
-  bsdtar -xf ./data.tar.gz -C "${pkgdir}/"
+  bsdtar -xf ${srcdir}/data.tar.gz -C ${pkgdir}/
 
   # Fix icon cache bug
   local hicolor="${pkgdir}/usr/share/icons/hicolor"
@@ -46,9 +39,10 @@ package() {
   # Fix directory permission bug
   chmod -R 755 ${pkgdir}/usr/bin
 
-  install -m644 ${pkgdir}/opt/$_pkgname/EULA.rtf $pkgdir/usr/share/licenses/$pkgname/LICENSE
+  install -m644 ${pkgdir}/opt/bitwig-studio/EULA.rtf \
+    ${pkgdir}/usr/share/licenses/${pkgname}/LICENSE
 
   # Fix launcher category
   sed -i 's:Categories=Multimedia:Categories=Multimedia;AudioVideo;Player;Recorder;:' \
-    $pkgdir/usr/share/applications/bitwig-studio.desktop
+    ${pkgdir}/usr/share/applications/bitwig-studio.desktop
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Bitwig GmbH <support at bitwig dot com>
 pkgname=bitwig-studio-demo
 _pkgname=bitwig-studio
-pkgver=1.3.1
+pkgver=1.3.2
 pkgrel=1
 pkgdesc="Music production system for production, remixing and performance"
 arch=( 'x86_64' )
@@ -23,7 +23,7 @@ provides=('bitwig-studio')
 conflicts=('bitwig-studio-demo-rc')
 options=(!strip)
 source=("https://downloads.bitwig.com/stable/${pkgver}/bitwig-studio-${pkgver}.deb")
-md5sums=('06b6a388f095529da6ceb92f6149073b')
+md5sums=('1e2785a134eb119760ba1703637283d9')
 
 package() {
   cd $srcdir
@@ -35,6 +35,16 @@ package() {
   install -d $pkgdir/usr/share/licenses/$pkgname
 
   bsdtar -xf ./data.tar.gz -C "${pkgdir}/"
+
+  # Fix icon cache bug
+  local hicolor="${pkgdir}/usr/share/icons/hicolor"
+  if [[ -f ${hicolor}/scalable/apps/bitwig-modular.sh ]]; then
+    # Rename .sh to .svg
+    mv ${hicolor}/scalable/apps/bitwig-modular.{sh,svg}
+  fi
+
+  # Fix directory permission bug
+  chmod -R 755 ${pkgdir}/usr/bin
 
   install -m644 ${pkgdir}/opt/$_pkgname/EULA.rtf $pkgdir/usr/share/licenses/$pkgname/LICENSE
 


### PR DESCRIPTION
Sorry, if these commits touch a lot of code. Check commit messages for more info.

Main changes:

* Update to 1.3.2;
* Fix: `gtk-update-icon-cache: The generated cache was invalid`;
* Fix: `warning: directory permissions differ on /usr/bin/`.